### PR TITLE
feat: implement task CRUD endpoints

### DIFF
--- a/server/Controllers/TasksController.cs
+++ b/server/Controllers/TasksController.cs
@@ -1,0 +1,18 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using FishyTodo.API.Data;
+using FishyTodo.API.Models;
+
+namespace FishyTodo.API.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class TasksController : ControllerBase
+{
+    private readonly AppDbContext _db;
+
+    public TasksController(AppDbContext db)
+    {
+        _db = db;
+    }
+}

--- a/server/Controllers/TasksController.cs
+++ b/server/Controllers/TasksController.cs
@@ -22,4 +22,12 @@ public class TasksController : ControllerBase
         var tasks = await _db.Tasks.ToListAsync();
         return Ok(tasks);
     }
+
+    [HttpGet("{id}")]
+    public async Task<IActionResult> GetById(int id)
+    {
+        var task = await _db.Tasks.FindAsync(id);
+        if (task is null) return NotFound();
+        return Ok(task);
+    }
 }

--- a/server/Controllers/TasksController.cs
+++ b/server/Controllers/TasksController.cs
@@ -53,4 +53,15 @@ public class TasksController : ControllerBase
         await _db.SaveChangesAsync();
         return Ok(task);
     }
+
+    [HttpDelete("{id}")]
+    public async Task<IActionResult> Delete(int id)
+    {
+        var task = await _db.Tasks.FindAsync(id);
+        if (task is null) return NotFound();
+
+        _db.Tasks.Remove(task);
+        await _db.SaveChangesAsync();
+        return NoContent();
+    }
 }

--- a/server/Controllers/TasksController.cs
+++ b/server/Controllers/TasksController.cs
@@ -39,4 +39,18 @@ public class TasksController : ControllerBase
         await _db.SaveChangesAsync();
         return CreatedAtAction(nameof(GetById), new { id = task.Id }, task);
     }
+
+    [HttpPut("{id}")]
+    public async Task<IActionResult> Update(int id, TaskItem updated)
+    {
+        var task = await _db.Tasks.FindAsync(id);
+        if (task is null) return NotFound();
+
+        task.Title = updated.Title;
+        task.Priority = updated.Priority;
+        task.Completed = updated.Completed;
+
+        await _db.SaveChangesAsync();
+        return Ok(task);
+    }
 }

--- a/server/Controllers/TasksController.cs
+++ b/server/Controllers/TasksController.cs
@@ -30,4 +30,13 @@ public class TasksController : ControllerBase
         if (task is null) return NotFound();
         return Ok(task);
     }
+
+    [HttpPost]
+    public async Task<IActionResult> Create(TaskItem task)
+    {
+        task.CreatedAt = DateTime.UtcNow;
+        _db.Tasks.Add(task);
+        await _db.SaveChangesAsync();
+        return CreatedAtAction(nameof(GetById), new { id = task.Id }, task);
+    }
 }

--- a/server/Controllers/TasksController.cs
+++ b/server/Controllers/TasksController.cs
@@ -15,4 +15,11 @@ public class TasksController : ControllerBase
     {
         _db = db;
     }
+
+    [HttpGet]
+    public async Task<IActionResult> GetAll()
+    {
+        var tasks = await _db.Tasks.ToListAsync();
+        return Ok(tasks);
+    }
 }

--- a/server/Data/AppDbContext.cs
+++ b/server/Data/AppDbContext.cs
@@ -1,0 +1,11 @@
+using Microsoft.EntityFrameworkCore;
+using FishyTodo.API.Models;
+
+namespace FishyTodo.API.Data;
+
+public class AppDbContext : DbContext
+{
+    public AppDbContext(DbContextOptions<AppDbContext> options) : base(options) { }
+
+    public DbSet<TaskItem> Tasks => Set<TaskItem>();
+}

--- a/server/FishyTodo.API.csproj
+++ b/server/FishyTodo.API.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.4" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.7" />
   </ItemGroup>
 

--- a/server/Models/TaskItem.cs
+++ b/server/Models/TaskItem.cs
@@ -1,0 +1,10 @@
+namespace FishyTodo.API.Models;
+
+public class TaskItem
+{
+    public int Id { get; set; }
+    public string Title { get; set; } = string.Empty;
+    public string Priority { get; set; } = "medium";
+    public bool Completed { get; set; } = false;
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+}

--- a/server/Program.cs
+++ b/server/Program.cs
@@ -1,4 +1,10 @@
+using Microsoft.EntityFrameworkCore;
+using FishyTodo.API.Data;
+
 var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddDbContext<AppDbContext>(opt =>
+    opt.UseInMemoryDatabase("FishyTodoDB"));
 
 builder.Services.AddControllers();
 builder.Services.AddEndpointsApiExplorer();


### PR DESCRIPTION
## Summary

This PR implements the main Task CRUD API for the FishyTodo Lab 7 back-end.

The API now includes a `TaskItem` entity and a controller for creating, reading, updating, and deleting tasks through REST endpoints.

## What changed

- Added the `TaskItem` model
- Added task properties:
  - `id`
  - `title`
  - `priority`
  - `completed`
  - `createdAt`
- Added a Tasks controller
- Implemented endpoint for retrieving all tasks
- Implemented endpoint for retrieving a task by ID
- Implemented endpoint for creating a new task
- Implemented endpoint for updating an existing task
- Implemented endpoint for deleting a task
- Added proper HTTP status codes for successful and failed operations

## API endpoints

| Method | Endpoint | Response |
|---|---|---|
| GET | `/api/tasks` | `200 OK` with all tasks |
| GET | `/api/tasks/{id}` | `200 OK` if found, `404 Not Found` if missing |
| POST | `/api/tasks` | `201 Created` with the created task |
| PUT | `/api/tasks/{id}` | `200 OK` if updated, `404 Not Found` if missing |
| DELETE | `/api/tasks/{id}` | `204 No Content` if deleted, `404 Not Found` if missing |

## Test plan

- [x] `GET /api/tasks` returns all existing tasks
- [x] `GET /api/tasks/{id}` returns the correct task when it exists
- [x] `GET /api/tasks/{id}` returns `404 Not Found` when the task does not exist
- [x] `POST /api/tasks` creates a new task and returns `201 Created`
- [x] `PUT /api/tasks/{id}` updates an existing task
- [x] `PUT /api/tasks/{id}` returns `404 Not Found` when the task does not exist
- [x] `DELETE /api/tasks/{id}` deletes an existing task and returns `204 No Content`
- [x] `DELETE /api/tasks/{id}` returns `404 Not Found` when the task does not exist
- [x] Endpoints are visible and testable in Swagger UI

## Notes

This PR completes the basic CRUD functionality for tasks. JWT protection, role-based permissions, pagination, and front-end integration will be handled in later issues.

Closes #2