### PR TITLE
feat: add JWT /token endpoint with roles and permissions

### DIFF
--- a/server/Controllers/TokenController.cs
+++ b/server/Controllers/TokenController.cs
@@ -1,0 +1,62 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.IdentityModel.Tokens;
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Text;
+using FishyTodo.API.Models;
+
+namespace FishyTodo.API.Controllers;
+
+[ApiController]
+[Route("[controller]")]
+public class TokenController : ControllerBase
+{
+    private readonly IConfiguration _config;
+
+    public TokenController(IConfiguration config)
+    {
+        _config = config;
+    }
+
+    [HttpPost]
+    public IActionResult GenerateToken([FromBody] TokenRequest request)
+    {
+        var role = request.Role.ToUpper();
+
+        if (role != "VISITOR" && role != "WRITER" && role != "ADMIN")
+            return BadRequest(new { error = "Invalid role. Must be VISITOR, WRITER, or ADMIN." });
+
+        var permissions = role switch
+        {
+            "ADMIN"   => new[] { "READ", "WRITE", "DELETE" },
+            "WRITER"  => new[] { "READ", "WRITE" },
+            _         => new[] { "READ" }
+        };
+
+        var claims = new List<Claim>
+        {
+            new Claim(ClaimTypes.Role, role),
+            new Claim("permissions", string.Join(",", permissions))
+        };
+
+        var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(_config["Jwt:Key"]!));
+        var creds = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
+        var expiration = int.Parse(_config["Jwt:ExpirationMinutes"]!);
+
+        var token = new JwtSecurityToken(
+            issuer: _config["Jwt:Issuer"],
+            audience: _config["Jwt:Audience"],
+            claims: claims,
+            expires: DateTime.UtcNow.AddMinutes(expiration),
+            signingCredentials: creds
+        );
+
+        return Ok(new
+        {
+            token = new JwtSecurityTokenHandler().WriteToken(token),
+            role,
+            permissions,
+            expiresIn = $"{expiration} minute(s)"
+        });
+    }
+}

--- a/server/FishyTodo.API.csproj
+++ b/server/FishyTodo.API.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.4" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.4" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.7" />
   </ItemGroup>

--- a/server/Models/TokenRequest.cs
+++ b/server/Models/TokenRequest.cs
@@ -1,0 +1,6 @@
+namespace FishyTodo.API.Models;
+
+public class TokenRequest
+{
+    public string Role { get; set; } = string.Empty;
+}

--- a/server/Program.cs
+++ b/server/Program.cs
@@ -1,10 +1,34 @@
+using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.IdentityModel.Tokens;
+using System.Text;
 using FishyTodo.API.Data;
 
 var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddDbContext<AppDbContext>(opt =>
     opt.UseInMemoryDatabase("FishyTodoDB"));
+
+var jwtKey = builder.Configuration["Jwt:Key"]!;
+var jwtIssuer = builder.Configuration["Jwt:Issuer"]!;
+var jwtAudience = builder.Configuration["Jwt:Audience"]!;
+
+builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+    .AddJwtBearer(options =>
+    {
+        options.TokenValidationParameters = new TokenValidationParameters
+        {
+            ValidateIssuer = true,
+            ValidateAudience = true,
+            ValidateLifetime = true,
+            ValidateIssuerSigningKey = true,
+            ValidIssuer = jwtIssuer,
+            ValidAudience = jwtAudience,
+            IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(jwtKey))
+        };
+    });
+
+builder.Services.AddAuthorization();
 
 builder.Services.AddControllers();
 builder.Services.AddEndpointsApiExplorer();
@@ -26,6 +50,8 @@ if (app.Environment.IsDevelopment())
 }
 
 app.UseHttpsRedirection();
+app.UseAuthentication();
+app.UseAuthorization();
 app.MapControllers();
 
 app.Run();

--- a/server/appsettings.json
+++ b/server/appsettings.json
@@ -5,5 +5,11 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "Jwt": {
+    "Key": "fishytodo-super-secret-key-for-lab7-demo-only",
+    "Issuer": "FishyTodoAPI",
+    "Audience": "FishyTodoClient",
+    "ExpirationMinutes": 1
+  }
 }


### PR DESCRIPTION
## Summary

This PR adds JWT authentication support to the FishyTodo ASP.NET Core API.

A new `/token` endpoint was added to generate signed JWTs for demo users based on their selected role. Each token includes role and permission claims and expires after 1 minute, as required for the lab demo.

## What changed

- Installed `Microsoft.AspNetCore.Authentication.JwtBearer` v9.0.4
- Added JWT configuration to `appsettings.json`
  - `Key`
  - `Issuer`
  - `Audience`
  - `ExpirationMinutes`
- Registered JWT authentication in `Program.cs`
- Registered authorization middleware in `Program.cs`
- Created `TokenRequest` model
- Added `POST /token` endpoint
- Added role-based permission mapping
- Generated signed JWT tokens with role and permission claims
- Set token expiration to 1 minute

## How it works

Send a `POST` request to `/token` with a role in the request body.

Example request:

`{ "role": "ADMIN" }`

The API returns a JWT token that can later be used to access protected endpoints.

## Supported roles and permissions

| Role | Permissions |
|---|---|
| `VISITOR` | `READ` |
| `WRITER` | `READ`, `WRITE` |
| `ADMIN` | `READ`, `WRITE`, `DELETE` |

## How to test in Swagger

1. Go to the server folder: `cd server`
2. Start the API: `dotnet run`
3. Open Swagger UI: `http://localhost:5112/`
4. Call `POST /token` with one of the supported roles
5. Copy the returned token value

## Test plan

- [x] `POST /token` with `VISITOR` returns a valid JWT with `READ` permission
- [x] `POST /token` with `WRITER` returns a valid JWT with `READ` and `WRITE` permissions
- [x] `POST /token` with `ADMIN` returns a valid JWT with `READ`, `WRITE`, and `DELETE` permissions
- [x] Invalid role returns `400 Bad Request`
- [x] Token contains role claim
- [x] Token contains permission claims
- [x] Token expires after 1 minute

## Notes

This PR adds token generation only. Protecting the task CRUD endpoints with JWT and role-based access rules will be handled in the next issue.

Closes #3 