### PR TITLE
feat: protect task endpoints with JWT role-based authorization

### DIFF
--- a/server/Controllers/TasksController.cs
+++ b/server/Controllers/TasksController.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using FishyTodo.API.Data;
@@ -7,6 +8,7 @@ namespace FishyTodo.API.Controllers;
 
 [ApiController]
 [Route("api/[controller]")]
+[Authorize]
 public class TasksController : ControllerBase
 {
     private readonly AppDbContext _db;
@@ -17,6 +19,7 @@ public class TasksController : ControllerBase
     }
 
     [HttpGet]
+    [Authorize(Roles = "VISITOR,WRITER,ADMIN")]
     public async Task<IActionResult> GetAll()
     {
         var tasks = await _db.Tasks.ToListAsync();
@@ -24,6 +27,7 @@ public class TasksController : ControllerBase
     }
 
     [HttpGet("{id}")]
+    [Authorize(Roles = "VISITOR,WRITER,ADMIN")]
     public async Task<IActionResult> GetById(int id)
     {
         var task = await _db.Tasks.FindAsync(id);
@@ -32,6 +36,7 @@ public class TasksController : ControllerBase
     }
 
     [HttpPost]
+    [Authorize(Roles = "WRITER,ADMIN")]
     public async Task<IActionResult> Create(TaskItem task)
     {
         task.CreatedAt = DateTime.UtcNow;
@@ -41,6 +46,7 @@ public class TasksController : ControllerBase
     }
 
     [HttpPut("{id}")]
+    [Authorize(Roles = "WRITER,ADMIN")]
     public async Task<IActionResult> Update(int id, TaskItem updated)
     {
         var task = await _db.Tasks.FindAsync(id);
@@ -55,6 +61,7 @@ public class TasksController : ControllerBase
     }
 
     [HttpDelete("{id}")]
+    [Authorize(Roles = "ADMIN")]
     public async Task<IActionResult> Delete(int id)
     {
         var task = await _db.Tasks.FindAsync(id);

--- a/server/FishyTodo.API.csproj
+++ b/server/FishyTodo.API.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.4" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.4" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.7" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.9.0" />
   </ItemGroup>
 
 </Project>

--- a/server/Program.cs
+++ b/server/Program.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.IdentityModel.Tokens;
+using Microsoft.OpenApi.Models;
 using System.Text;
 using FishyTodo.API.Data;
 
@@ -35,6 +36,27 @@ builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen(c =>
 {
     c.SwaggerDoc("v1", new() { Title = "FishyTodo API", Version = "v1" });
+
+    c.AddSecurityDefinition("Bearer", new OpenApiSecurityScheme
+    {
+        Name = "Authorization",
+        Type = SecuritySchemeType.Http,
+        Scheme = "Bearer",
+        BearerFormat = "JWT",
+        In = ParameterLocation.Header,
+        Description = "Paste your JWT token here. Get one from POST /token first."
+    });
+
+    c.AddSecurityRequirement(new OpenApiSecurityRequirement
+    {
+        {
+            new OpenApiSecurityScheme
+            {
+                Reference = new OpenApiReference { Type = ReferenceType.SecurityScheme, Id = "Bearer" }
+            },
+            Array.Empty<string>()
+        }
+    });
 });
 
 var app = builder.Build();


### PR DESCRIPTION
## Summary

This PR protects the Task CRUD API using JWT authentication and role-based authorization.

All task endpoints now require a valid JWT. Access is restricted based on the role stored inside the token, following the Lab 7 permission requirements.

## What changed

- Added `[Authorize]` to all `TasksController` endpoints
- Applied role-based access rules for each CRUD operation
- Allowed all roles to read tasks
- Allowed only `WRITER` and `ADMIN` to create and update tasks
- Allowed only `ADMIN` to delete tasks
- Added JWT authorization support to Swagger UI
- Added the Swagger `Authorize` button for easier token testing
- Downgraded Swashbuckle to `6.9.0` for stable compatibility with .NET 9

## Access rules

| Endpoint | VISITOR | WRITER | ADMIN |
|---|---|---|---|
| `GET /api/tasks` | ✅ | ✅ | ✅ |
| `GET /api/tasks/{id}` | ✅ | ✅ | ✅ |
| `POST /api/tasks` | ❌ 403 | ✅ | ✅ |
| `PUT /api/tasks/{id}` | ❌ 403 | ✅ | ✅ |
| `DELETE /api/tasks/{id}` | ❌ 403 | ❌ 403 | ✅ |
| No token | ❌ 401 | ❌ 401 | ❌ 401 |

## How to test in Swagger

1. Go to the server folder: `cd server`
2. Start the API: `dotnet run`
3. Open Swagger UI: `http://localhost:5112/`
4. Call `POST /token` with a role body, for example: `{ "role": "ADMIN" }`
5. Copy the returned token value
6. Click the `Authorize` button at the top of Swagger UI
7. Paste the token and click `Authorize`
8. Try the task endpoints and check that access matches the role rules

## Test plan

- [x] Calling any task endpoint without a token returns `401 Unauthorized`
- [x] `VISITOR` token can call `GET /api/tasks`
- [x] `VISITOR` token can call `GET /api/tasks/{id}`
- [x] `VISITOR` token receives `403 Forbidden` for `POST /api/tasks`
- [x] `VISITOR` token receives `403 Forbidden` for `PUT /api/tasks/{id}`
- [x] `VISITOR` token receives `403 Forbidden` for `DELETE /api/tasks/{id}`
- [x] `WRITER` token can call `GET`, `POST`, and `PUT` endpoints
- [x] `WRITER` token receives `403 Forbidden` for `DELETE /api/tasks/{id}`
- [x] `ADMIN` token can call all task endpoints
- [x] Swagger UI allows testing protected endpoints with a JWT

## Notes

This PR completes JWT protection for the Task CRUD API. Pagination and front-end integration will be handled in the next issues.

Closes #4