### PR TITLE
feat: deploy frontend to GitHub Pages with GitHub Actions

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -1,0 +1,43 @@
+name: Deploy Frontend to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'client/**'
+      - '.github/workflows/deploy-frontend.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: client/package-lock.json
+
+      - name: Install dependencies
+        working-directory: client
+        run: npm ci
+
+      - name: Build
+        working-directory: client
+        run: npm run build
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: client/dist
+          publish_branch: gh-pages

--- a/client/.env.production
+++ b/client/.env.production
@@ -1,0 +1,2 @@
+VITE_API_BASE_URL=https://fishytodo-api.onrender.com
+VITE_BASE_PATH=/FishyTodo-Fullstack/

--- a/client/index.html
+++ b/client/index.html
@@ -11,6 +11,17 @@
   </head>
   <body>
     <div id="root"></div>
+    <script>
+      // Restore path from GitHub Pages 404 redirect (?p=encoded-path)
+      (function () {
+        var p = new URLSearchParams(window.location.search).get('p');
+        if (p) {
+          var base = window.location.pathname.replace(/\/$/, '');
+          var decoded = decodeURIComponent(p);
+          window.history.replaceState(null, '', base + decoded);
+        }
+      })();
+    </script>
     <script type="module" src="/src/main.jsx"></script>
   </body>
 </html>

--- a/client/public/404.html
+++ b/client/public/404.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>FishyToDo</title>
+    <script>
+      var base = '/FishyTodo-Fullstack';
+      var path = window.location.pathname.slice(base.length) || '/';
+      var search = window.location.search;
+      var hash = window.location.hash;
+      window.location.replace(
+        base + '/?p=' + encodeURIComponent(path + search) + hash
+      );
+    </script>
+  </head>
+  <body></body>
+</html>

--- a/server/Program.cs
+++ b/server/Program.cs
@@ -102,15 +102,12 @@ using (var scope = app.Services.CreateScope())
     db.Database.Migrate();
 }
 
-if (app.Environment.IsDevelopment())
+app.UseSwagger();
+app.UseSwaggerUI(c =>
 {
-    app.UseSwagger();
-    app.UseSwaggerUI(c =>
-    {
-        c.SwaggerEndpoint("/swagger/v1/swagger.json", "FishyTodo API v1");
-        c.RoutePrefix = string.Empty;
-    });
-}
+    c.SwaggerEndpoint("/swagger/v1/swagger.json", "FishyTodo API v1");
+    c.RoutePrefix = string.Empty; // Swagger at root: https://fishytodo-api.onrender.com
+});
 
 if (app.Environment.IsDevelopment()) app.UseHttpsRedirection();
 app.UseCors("FishyTodoCors");


### PR DESCRIPTION
## Summary

Closes #14 

Sets up automated deployment of the FishyTodo React frontend to GitHub Pages and connects the production build to the live Render API.

This PR also exposes Swagger UI on the deployed Render backend so the API can be tested more easily during demos.

## Changes

### Client

- Added `.env.production` for the production frontend build
- Set `VITE_API_BASE_URL` to the live Render backend:

  `https://fishytodo-api.onrender.com`

- Set `VITE_BASE_PATH` to the GitHub Pages repo subpath:

  `/FishyTodo-Fullstack/`

- Added `public/404.html` with a redirect script for GitHub Pages SPA routing
- Updated `index.html` to restore the original route from the `?p=` query parameter before React starts
- Ensured page refreshes on nested routes continue to work correctly

### CI / Deployment

- Added `.github/workflows/deploy-frontend.yml`
- Configured the workflow to run on pushes to `main` that affect `client/**`
- Configured the workflow to build the Vite React app
- Configured deployment of `client/dist` to the `gh-pages` branch using `peaceiris/actions-gh-pages`

### API

- Removed the `IsDevelopment()` guard around Swagger configuration
- Swagger UI is now available on the live Render API for demo/testing access:

  `https://fishytodo-api.onrender.com`

## Manual step required after merge

After merging, GitHub Pages still needs to be enabled manually:

Go to:

`Settings → Pages → Source`

Then set:

- Branch: `gh-pages`
- Folder: `/root`

## Test plan

- [ ] GitHub Action runs successfully after merge to `main`
- [ ] `gh-pages` branch is created with the built frontend assets
- [ ] App loads at `https://patriciamoraru.github.io/FishyTodo-Fullstack/`
- [ ] Refreshing `/tank` does not show a GitHub Pages 404
- [ ] Refreshing `/mood` does not show a GitHub Pages 404
- [ ] Refreshing `/settings` does not show a GitHub Pages 404
- [ ] Tasks load from `https://fishytodo-api.onrender.com`
- [ ] Swagger is accessible at `https://fishytodo-api.onrender.com`

## Acceptance criteria checklist

- [x] Pushing to `main` triggers an automatic frontend build and deploy
- [x] The app is configured for `https://patriciamoraru.github.io/FishyTodo-Fullstack/`
- [x] GitHub Pages SPA routing fallback is added
- [x] Frontend production build points to `https://fishytodo-api.onrender.com`
- [x] Swagger UI is available on the deployed Render API