### PR TITLE
feat: add role-based login flow

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,9 +1,10 @@
-import { BrowserRouter, Routes, Route, Outlet } from 'react-router-dom'
+import { BrowserRouter, Routes, Route, Outlet, Navigate } from 'react-router-dom'
 import Navbar from './components/Navbar'
 import TankView from './components/TankView'
 import ListView from './components/ListView'
 import SettingsView from './components/SettingsView'
 import LandingView from './components/LandingView'
+import LoginView from './components/LoginView'
 import MoodReefView from './components/MoodReefView'
 import { TaskProvider } from './context/TaskContext'
 import { ThemeProvider, useTheme } from './context/ThemeContext'
@@ -38,11 +39,13 @@ export default function App() {
       <BrowserRouter basename={routerBasename}>
         <Routes>
           <Route path="/" element={<LandingView />} />
+          <Route path="/login" element={<LoginView />} />
           <Route element={<AppLayout />}>
             <Route path="/tank" element={<HomeView />} />
             <Route path="/mood" element={<MoodReefView />} />
             <Route path="/settings" element={<SettingsView />} />
           </Route>
+          <Route path="*" element={<Navigate to="/login" replace />} />
         </Routes>
       </BrowserRouter>
     </MoodProvider>

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -9,8 +9,14 @@ import MoodReefView from './components/MoodReefView'
 import { TaskProvider } from './context/TaskContext'
 import { ThemeProvider, useTheme } from './context/ThemeContext'
 import { MoodProvider } from './context/MoodContext'
+import { isLoggedIn } from './utils/taskApi'
 import './App.css'
 import './style.css'
+
+function ProtectedRoute() {
+  if (!isLoggedIn()) return <Navigate to="/login" replace />
+  return <Outlet />
+}
 
 function HomeView() {
   const { listView } = useTheme()
@@ -40,10 +46,12 @@ export default function App() {
         <Routes>
           <Route path="/" element={<LandingView />} />
           <Route path="/login" element={<LoginView />} />
-          <Route element={<AppLayout />}>
-            <Route path="/tank" element={<HomeView />} />
-            <Route path="/mood" element={<MoodReefView />} />
-            <Route path="/settings" element={<SettingsView />} />
+          <Route element={<ProtectedRoute />}>
+            <Route element={<AppLayout />}>
+              <Route path="/tank" element={<HomeView />} />
+              <Route path="/mood" element={<MoodReefView />} />
+              <Route path="/settings" element={<SettingsView />} />
+            </Route>
           </Route>
           <Route path="*" element={<Navigate to="/login" replace />} />
         </Routes>

--- a/client/src/components/LandingView.jsx
+++ b/client/src/components/LandingView.jsx
@@ -30,7 +30,7 @@ export default function LandingView() {
         </p>
         <button
           className="btn btn-primary landing-cta"
-          onClick={() => navigate('/tank')}
+          onClick={() => navigate('/login')}
           aria-label="Enter the task tank"
         >
           let&apos;s swim →

--- a/client/src/components/ListView.jsx
+++ b/client/src/components/ListView.jsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import { useTaskContext } from '../context/TaskContext'
 import { getFishImage } from '../utils/fishImages'
 import TaskApiStatus from './TaskApiStatus'
+import TankBar from './TankBar'
 import './ListView.css'
 
 const PRIORITY_ORDER = ['whale', 'big', 'medium', 'small', 'tiny']
@@ -28,6 +29,7 @@ export default function ListView() {
     <div className="list-view screen">
       <div className="list-inner">
         <TaskApiStatus />
+        <TankBar />
 
         <div className="filter-bar" role="group" aria-label="Filter by priority">
           {FILTERS.map(f => (

--- a/client/src/components/LoginView.css
+++ b/client/src/components/LoginView.css
@@ -1,0 +1,190 @@
+/* ════════════════════════════════════════════════════
+   FishyTodo · login page stylesheet
+   Watercolor notebook · Sunset Cream palette
+════════════════════════════════════════════════════ */
+
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+/* ── tokens ──────────────────────────────────────── */
+.login-page {
+  font-family: 'Quicksand', sans-serif;
+  --paper:       #fdf0e2;
+  --paper-warm:  #f9dec3;
+  --paper-card:  #fffaf0;
+  --ink:         #3d2418;
+  --ink-soft:    #6e4e3a;
+  --line:        rgba(110, 78, 58, 0.18);
+  --line-strong: rgba(110, 78, 58, 0.32);
+  --shadow-sm:   0 2px 6px  rgba(110, 78, 58, 0.10);
+  --shadow-md:   0 4px 14px rgba(110, 78, 58, 0.12);
+  --shadow-lg:   0 10px 28px rgba(110, 78, 58, 0.14);
+  --accent:      #c85a3a;
+  --accent-soft: #e08868;
+  --sec:         #a890c4;
+  --tert:        #f0b89c;
+
+  position: relative;
+  width: 100vw;
+  height: 100vh;
+  overflow: hidden;
+  background: radial-gradient(ellipse at top, var(--paper-warm) 0%, var(--paper) 70%);
+  color: var(--ink);
+}
+
+/* ── ambient decoration ──────────────────────────── */
+.dashed-frame {
+  position: absolute; inset: 24px;
+  border: 1.5px dashed var(--line);
+  border-radius: 18px;
+  pointer-events: none;
+  z-index: 1;
+}
+.ambient-fish {
+  position: absolute;
+  pointer-events: none;
+  user-select: none;
+}
+.ambient-fish.f1 { width: 130px; top: 70px;  left: 90px;  opacity: 0.35; transform: rotate(-10deg); }
+.ambient-fish.f2 { width: 110px; top: 130px; right: 120px; opacity: 0.40; transform: scaleX(-1) rotate(8deg); }
+.ambient-fish.f3 { width: 80px;  bottom: 140px; left: 130px; opacity: 0.30; transform: rotate(-14deg); }
+.ambient-fish.f4 { width: 90px;  bottom: 90px;  right: 160px; opacity: 0.32; transform: scaleX(-1) rotate(6deg); }
+
+.bottom-waves {
+  position: absolute;
+  bottom: 0; left: 0;
+  width: 100%;
+  height: 80px;
+  pointer-events: none;
+}
+
+/* ── login card ──────────────────────────────────── */
+.login-card {
+  position: absolute;
+  top: 50%; left: 50%;
+  transform: translate(-50%, -50%) rotate(-0.6deg);
+  width: 460px;
+  max-width: calc(100% - 60px);
+  background: var(--paper-card);
+  border: 1.5px solid var(--line);
+  border-radius: 18px;
+  padding: 40px 44px 36px;
+  box-shadow: var(--shadow-lg);
+  z-index: 2;
+}
+
+/* ── brand ───────────────────────────────────────── */
+.login-brand {
+  text-align: center;
+  margin-bottom: 28px;
+}
+.login-brand .logo {
+  font-family: 'Caveat', cursive;
+  font-size: 60px;
+  line-height: 1;
+  display: inline-block;
+  transform: rotate(-1deg);
+  color: var(--ink);
+}
+.login-brand .tagline {
+  font-family: 'Patrick Hand', cursive;
+  font-size: 15px;
+  color: var(--ink-soft);
+  margin-top: 4px;
+}
+
+/* ── role picker ─────────────────────────────────── */
+.role-label {
+  font-family: 'Patrick Hand', cursive;
+  font-size: 14px;
+  color: var(--ink-soft);
+  margin-bottom: 10px;
+  margin-left: 2px;
+  display: block;
+}
+
+.role-picker {
+  display: flex;
+  gap: 10px;
+  margin-bottom: 24px;
+}
+
+.role-card {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  padding: 14px 8px;
+  background: var(--paper);
+  border: 1.5px solid var(--line-strong);
+  border-radius: 14px;
+  cursor: pointer;
+  transition: border-color 0.15s, box-shadow 0.15s, transform 0.12s;
+  user-select: none;
+}
+.role-card:hover {
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-md);
+}
+.role-card.selected {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px rgba(200, 90, 58, 0.15);
+  background: var(--paper-card);
+}
+.role-card .role-icon {
+  font-size: 22px;
+  line-height: 1;
+}
+.role-card .role-name {
+  font-family: 'Caveat', cursive;
+  font-size: 20px;
+  color: var(--ink);
+  line-height: 1;
+}
+.role-card .role-desc {
+  font-family: 'Patrick Hand', cursive;
+  font-size: 11px;
+  color: var(--ink-soft);
+  text-align: center;
+  line-height: 1.3;
+}
+.role-card.selected .role-name {
+  color: var(--accent);
+}
+
+/* ── error ───────────────────────────────────────── */
+.login-error {
+  font-family: 'Patrick Hand', cursive;
+  font-size: 14px;
+  color: var(--accent);
+  text-align: center;
+  margin-bottom: 14px;
+}
+
+/* ── primary button ──────────────────────────────── */
+.login-btn {
+  font-family: 'Caveat', cursive;
+  width: 100%;
+  font-size: 28px;
+  padding: 10px 0;
+  border: none;
+  border-radius: 50px;
+  background: var(--accent);
+  color: var(--paper);
+  box-shadow: 0 4px 14px rgba(200, 90, 58, 0.28);
+  cursor: pointer;
+  transition: transform 0.12s ease, box-shadow 0.12s ease, opacity 0.12s;
+  user-select: none;
+}
+.login-btn:hover:not(:disabled)  { transform: translateY(-1px); box-shadow: 0 6px 20px rgba(200, 90, 58, 0.36); }
+.login-btn:active:not(:disabled) { transform: translateY(1px);  box-shadow: 0 4px 14px rgba(200, 90, 58, 0.28); }
+.login-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+
+/* ── responsive ──────────────────────────────────── */
+@media (max-width: 520px) {
+  .login-card { padding: 32px 22px 28px; width: calc(100% - 40px); }
+  .login-brand .logo { font-size: 50px; }
+  .ambient-fish { display: none; }
+  .dashed-frame { inset: 14px; }
+  .role-card .role-desc { display: none; }
+}

--- a/client/src/components/LoginView.css
+++ b/client/src/components/LoginView.css
@@ -1,8 +1,3 @@
-/* ════════════════════════════════════════════════════
-   FishyTodo · login page stylesheet
-   Watercolor notebook · Sunset Cream palette
-════════════════════════════════════════════════════ */
-
 *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 
 /* ── tokens ──────────────────────────────────────── */

--- a/client/src/components/LoginView.jsx
+++ b/client/src/components/LoginView.jsx
@@ -4,7 +4,7 @@ import fish1 from '../assets/fish1.png'
 import fish2 from '../assets/fish2.png'
 import fish3 from '../assets/fish3.png'
 import fish4 from '../assets/fish4.png'
-import { setDemoJwtRole } from '../utils/taskApi'
+import { setDemoJwtRole, ensureJwt } from '../utils/taskApi'
 import { APP_TITLE } from '../branding.js'
 import './LoginView.css'
 
@@ -40,9 +40,10 @@ export default function LoginView() {
     setLoading(true)
     try {
       setDemoJwtRole(selected)
+      await ensureJwt()
       navigate('/tank')
     } catch (e) {
-      setError(e.message ?? 'Something went wrong')
+      setError(e.message ?? 'Something went wrong, try again')
     } finally {
       setLoading(false)
     }

--- a/client/src/components/LoginView.jsx
+++ b/client/src/components/LoginView.jsx
@@ -1,0 +1,117 @@
+import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import fish1 from '../assets/fish1.png'
+import fish2 from '../assets/fish2.png'
+import fish3 from '../assets/fish3.png'
+import fish4 from '../assets/fish4.png'
+import { setDemoJwtRole } from '../utils/taskApi'
+import { APP_TITLE } from '../branding.js'
+import './LoginView.css'
+
+const ROLES = [
+  {
+    id: 'VISITOR',
+    icon: '👁️',
+    name: 'visitor',
+    desc: 'browse tasks, read-only',
+  },
+  {
+    id: 'WRITER',
+    icon: '✏️',
+    name: 'writer',
+    desc: 'add & complete tasks',
+  },
+  {
+    id: 'ADMIN',
+    icon: '🐡',
+    name: 'admin',
+    desc: 'full access, delete too',
+  },
+]
+
+export default function LoginView() {
+  const navigate = useNavigate()
+  const [selected, setSelected] = useState('ADMIN')
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState(null)
+
+  async function handleDiveIn() {
+    setError(null)
+    setLoading(true)
+    try {
+      setDemoJwtRole(selected)
+      navigate('/tank')
+    } catch (e) {
+      setError(e.message ?? 'Something went wrong')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="login-page">
+      <div className="dashed-frame" aria-hidden="true" />
+
+      <img src={fish1} className="ambient-fish f1" alt="" aria-hidden="true" />
+      <img src={fish2} className="ambient-fish f2" alt="" aria-hidden="true" />
+      <img src={fish3} className="ambient-fish f3" alt="" aria-hidden="true" />
+      <img src={fish4} className="ambient-fish f4" alt="" aria-hidden="true" />
+
+      <div className="login-card" role="main">
+        <div className="login-brand">
+          <div className="logo">{APP_TITLE}</div>
+          <div className="tagline">welcome back to your tank</div>
+        </div>
+
+        <span className="role-label">swim in as…</span>
+        <div className="role-picker" role="radiogroup" aria-label="Select role">
+          {ROLES.map(role => (
+            <button
+              key={role.id}
+              className={`role-card${selected === role.id ? ' selected' : ''}`}
+              onClick={() => setSelected(role.id)}
+              role="radio"
+              aria-checked={selected === role.id}
+              aria-label={`${role.name} — ${role.desc}`}
+            >
+              <span className="role-icon" aria-hidden="true">{role.icon}</span>
+              <span className="role-name">{role.name}</span>
+              <span className="role-desc">{role.desc}</span>
+            </button>
+          ))}
+        </div>
+
+        {error && <p className="login-error">{error}</p>}
+
+        <button
+          className="login-btn"
+          onClick={handleDiveIn}
+          disabled={loading}
+        >
+          {loading ? 'diving in…' : 'dive in →'}
+        </button>
+      </div>
+
+      <svg
+        className="bottom-waves"
+        viewBox="0 0 1200 80"
+        preserveAspectRatio="none"
+        aria-hidden="true"
+      >
+        <path
+          d="M0 50 Q 80 15 160 50 T 320 50 T 480 50 T 640 50 T 800 50 T 960 50 T 1120 50 T 1200 50"
+          stroke="var(--tert)"
+          strokeWidth="3"
+          fill="none"
+        />
+        <path
+          d="M0 60 Q 80 30 160 60 T 320 60 T 480 60 T 640 60 T 800 60 T 960 60 T 1120 60 T 1200 60"
+          stroke="var(--sec)"
+          strokeWidth="2"
+          fill="none"
+          opacity="0.6"
+        />
+      </svg>
+    </div>
+  )
+}

--- a/client/src/components/Navbar.css
+++ b/client/src/components/Navbar.css
@@ -55,6 +55,22 @@
   font-size: 1.6rem;
 }
 
+.nav-logout {
+  font-family: 'Patrick Hand', cursive;
+  font-size: 1.3rem;
+  color: var(--ink-soft);
+  background: var(--paper-warm);
+  border: 1.5px solid var(--line);
+  border-radius: 20px;
+  padding: 0.3rem 0.9rem;
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
+}
+.nav-logout:hover {
+  background: var(--tert);
+  color: var(--ink);
+}
+
 @media (max-width: 480px) {
   .navbar {
     padding: 0 1.2rem;

--- a/client/src/components/Navbar.jsx
+++ b/client/src/components/Navbar.jsx
@@ -1,10 +1,18 @@
-import { NavLink } from 'react-router-dom'
+import { NavLink, useNavigate } from 'react-router-dom'
 import { useTheme } from '../context/ThemeContext'
 import { APP_TITLE } from '../branding.js'
+import { clearJwt, getDemoRole } from '../utils/taskApi'
 import './Navbar.css'
 
 export default function Navbar() {
   const { theme, toggleTheme } = useTheme()
+  const navigate = useNavigate()
+  const role = getDemoRole()
+
+  function handleLogout() {
+    clearJwt()
+    navigate('/login')
+  }
 
   return (
     <nav className="navbar">
@@ -23,6 +31,9 @@ export default function Navbar() {
         </NavLink>
         <button className="icon-btn theme-toggle" onClick={toggleTheme} title="Toggle theme">
           {theme === 'light' ? '☾' : '☀'}
+        </button>
+        <button className="nav-logout" onClick={handleLogout} title={`Logged in as ${role}`}>
+          {role.toLowerCase()} ✕
         </button>
       </div>
     </nav>

--- a/client/src/components/Navbar.jsx
+++ b/client/src/components/Navbar.jsx
@@ -1,7 +1,7 @@
 import { NavLink, useNavigate } from 'react-router-dom'
 import { useTheme } from '../context/ThemeContext'
 import { APP_TITLE } from '../branding.js'
-import { clearJwt, getDemoRole } from '../utils/taskApi'
+import { logout, getDemoRole } from '../utils/taskApi'
 import './Navbar.css'
 
 export default function Navbar() {
@@ -10,7 +10,7 @@ export default function Navbar() {
   const role = getDemoRole()
 
   function handleLogout() {
-    clearJwt()
+    logout()
     navigate('/login')
   }
 

--- a/client/src/utils/taskApi.js
+++ b/client/src/utils/taskApi.js
@@ -34,6 +34,17 @@ export function clearJwt() {
   localStorage.removeItem(TOKEN_STORAGE)
 }
 
+/** Returns true only if the user has explicitly logged in (role stored). */
+export function isLoggedIn() {
+  return localStorage.getItem(ROLE_STORAGE) !== null
+}
+
+/** Full logout — clears both the JWT and the stored role. */
+export function logout() {
+  localStorage.removeItem(TOKEN_STORAGE)
+  localStorage.removeItem(ROLE_STORAGE)
+}
+
 async function fetchToken(role) {
   const res = await fetch(`${API_BASE}/token`, {
     method: 'POST',


### PR DESCRIPTION
## Summary

Closes #15 

Adds a real login flow to FishyTodo, replacing the previous automatic demo JWT fetch.

Users now choose a role before entering the app, receive a JWT from the backend, and use that token for protected API requests.

## Changes

### Authentication

- Added a dedicated `LoginView` page
- Added role selection for:
  - `VISITOR`
  - `WRITER`
  - `ADMIN`
- Calls `POST /token` with the selected role when logging in
- Stores the returned JWT in `localStorage`
- Reuses the stored JWT for protected API requests
- Redirects users to `/tank` after successful login

### Route protection

- Redirects unauthenticated users to `/login`
- Prevents users without a token from accessing the main task pages
- Keeps authenticated users inside the app after login

### Navbar

- Added a logout button
- Logout clears the stored JWT token
- Logout redirects the user back to the login page

## Test plan

- [ ] Open the app without a stored JWT
- [ ] Verify the user is redirected to `/login`
- [ ] Select `VISITOR` and log in
- [ ] Verify a JWT is stored in `localStorage`
- [ ] Verify the app redirects to `/tank`
- [ ] Verify protected API requests include the JWT token
- [ ] Click logout
- [ ] Verify the JWT is removed from `localStorage`
- [ ] Verify the user is redirected back to `/login`
- [ ] Repeat login with `WRITER` and `ADMIN`

## Acceptance criteria checklist

- [x] User must log in before seeing tasks
- [x] User can choose a role before receiving a token
- [x] JWT is stored in `localStorage`
- [x] JWT is used in subsequent API requests
- [x] Logout clears the token
- [x] Logout returns the user to the login page